### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     types: [opened, edited, reopened]
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   mark-stale-issues:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gpt-computer/gpt-computer/security/code-scanning/2](https://github.com/gpt-computer/gpt-computer/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/automation.yml` so the `GITHUB_TOKEN` scopes are constrained and documented.  
Best single fix here (without changing behavior) is to define workflow-level permissions right after the trigger block and before `jobs:`. For `actions/stale`, grant only what it needs to mark/comment/close issues and PRs:

- `contents: read` (safe baseline)
- `issues: write`
- `pull-requests: write`

This keeps current functionality while enforcing least privilege and satisfying the CodeQL check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Build:
- Add an explicit permissions block to the automation workflow limiting GITHUB_TOKEN scopes to read contents and write issues and pull requests.